### PR TITLE
fix: peerConnectionAddICECandidateAsync getString

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -921,9 +921,19 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         PeerConnection peerConnection = getPeerConnection(id);
         Log.d(TAG, "peerConnectionAddICECandidate() start");
         if (peerConnection != null) {
+            String sdpMid;
+            int sdpMLineIndex;
+            try {
+                sdpMid = candidateMap.getString("sdpMid");
+                sdpMLineIndex = candidateMap.getInt("sdpMLineIndex");
+            } catch (Exception e) {
+                Log.d("%s", String.valueOf(e));
+                sdpMid = "";
+                sdpMLineIndex = 0;
+            }
             IceCandidate candidate = new IceCandidate(
-                    candidateMap.getString("sdpMid"),
-                    candidateMap.getInt("sdpMLineIndex"),
+                    sdpMid,
+                    sdpMLineIndex,
                     candidateMap.getString("candidate")
             );
             result = peerConnection.addIceCandidate(candidate);


### PR DESCRIPTION
candidateMap.getString("sdpMid"); have a error
because some of case sdpMid return null
but peerConnectionAddICECandidateAsync function doesn't have exception handling to get sdpMid